### PR TITLE
Faire remonter le mode de paiement CmCiC sur le webservice de ISI

### DIFF
--- a/Config/config.xml
+++ b/Config/config.xml
@@ -19,6 +19,10 @@
 
             <tag name="kernel.event_subscriber"/>
         </service>
+
+        <service id="cmcic.provider.cmcic_module_conf_provider" class="CmCIC\Provider\CmCICModuleConfProvider">
+            <tag name="core.payment_module_conf"/>
+        </service>
     </services>
 
 </config>

--- a/Provider/CmCICModuleConfProvider.php
+++ b/Provider/CmCICModuleConfProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CmCIC\Provider;
+
+use ApyUtilities\Provider\AbstractPaymentModuleConf;
+use CmCIC\CmCIC;
+use stdClass;
+
+/**
+ * Class CmCICModuleConfProvider
+ * @package CmCIC\Provider
+ */
+class CmCICModuleConfProvider extends AbstractPaymentModuleConf
+{
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string
+    {
+        return 'CmCIC';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getID(): string
+    {
+        return self::getJsonData('CMCIC_TPE');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getActive(): bool
+    {
+        return !empty(self::getJsonData('CMCIC_TPE'));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getData(): stdClass
+    {
+        return (object)[
+            'CMCIC_TPE'         => self::getJsonData('CMCIC_TPE'),
+            'CMCIC_KEY'         => self::getJsonData('CMCIC_KEY'),
+            'CMCIC_CODESOCIETE' => self::getJsonData('CMCIC_CODESOCIETE'),
+            'CMCIC_SERVER'      => self::getJsonData('CMCIC_SERVER')
+        ];
+    }
+
+    /**
+     * Récupère les données dans le fichier JSON selon la clé donnée en paramètre
+     * @param string $key
+     * @return mixed
+     */
+    private function getJsonData(string $key)
+    {
+        $values = null;
+        $path   = __DIR__ . '/../' . CmCIC::JSON_CONFIG_PATH;
+        if (is_readable($path)) {
+            $values = json_decode(file_get_contents($path), true);
+        }
+
+        return $values[$key];
+    }
+}


### PR DESCRIPTION
### Type de MR
FEATURE

### Ticket
https://www.demandedesupport.com/issues/889381

### Impact
interne

### Phrase de description dans le mail de livraison
`Remonter les informations des moyens de paiement Payzone et CmCIC dans notre webservice ISI` 

### Procédure de tests
+ **TEST du module Payzone :** 
  + Cloner le repo dans local/modules
  + Activer le module avec la commande `php Thelia mod:act ApyPayzone`
  + Passer sur ma branche
  + Executer la commande `php Thelia apy-utilities:get-payment-modules-conf`
  + Vérifier que Payzone s'affiche et que ses données soient correctes (configuration dans paramétrage console -> modes de paiement Payzone)
+ **TEST du module CmCIC :** 
  + Cloner le repo dans local/modules
  + Activer le module avec la commande `php Thelia mod:act CmCIC`
  + Passer sur ma branche
  + Executer la commande `php Thelia apy-utilities:get-payment-modules-conf`
  + Vérifier que CmCIC s'affiche et que ses données soient correctes (configuration dans configuration avancée -> modules -> CmCIC)
+ Ces données sont ensuite récupérées dans ISI pour les inscrire dans un fichier que va ressortir notre webservice
### Explication plus technique
+ Création de provider dans les modules manquant pour que la commande Thelia affiche l'intégralité des modes de paiement à renvoyer dans le webservice de ISI

### Lié aux MR ::
+ https://git.centraldev.api-and-you.com/apymybox/ApyPayzone/-/merge_requests/25
+ https://github.com/lesateliersapicius/CmCIC/pull/6